### PR TITLE
Add docs for beam-client-java to site

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/beam-client-java"]
 	path = src/beam-client-java
-	url = git@github.com:MCProHosting/beam-client-java.git
+	url = https://github.com/MCProHosting/beam-client-java

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/beam-client-java"]
+	path = src/beam-client-java
+	url = git@github.com:MCProHosting/beam-client-java.git

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,9 +43,14 @@ gulp.task('images', function() {
         })))
         .pipe(gulp.dest('static/img'));
 });
+gulp.task('javadocs', $.shell.task([
+    'cd ./src/beam-client-java && git pull origin master',
+    'cd ./src/beam-client-java && mvn clean site'
+]));
 gulp.task('misc', function () {
     gulp.src('src/static/**/*.{ico,eot,woff,ttf,php}').pipe(gulp.dest('static'));
     gulp.src('src/static/doc/**/*.*').pipe(gulp.dest('static/doc'));
+    gulp.src('src/beam-client-java/target/site/**/*.*').pipe(gulp.dest('static/doc/java-client'));
 });
 
 gulp.task('setProduction', function() {
@@ -53,4 +58,4 @@ gulp.task('setProduction', function() {
 });
 
 gulp.task('dist', ['setProduction', 'default']);
-gulp.task('default', ['js', 'css', 'images', 'misc']);
+gulp.task('default', ['js', 'css', 'images', 'javadocs', 'misc']);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-less": "^2.0.1",
     "gulp-load-plugins": "^0.7.1",
     "gulp-minify-css": "^0.3.13",
+    "gulp-shell": "^0.4.0",
     "gulp-uglify": "^1.1.0",
     "jade": "^1.9.1",
     "knex": "^0.7.3",

--- a/src/template/index.jade
+++ b/src/template/index.jade
@@ -11,8 +11,7 @@ block content
         .col-sm-6
             h2 Client Libraries
 
-            p We provide several client libraries for easily interacting with the Beam API! These are currently all works-in-progress. Information regarding the documentation of some of these libraries can be found 
-                a(href='#client-docs') below.
+            p We provide several client libraries for easily interacting with the Beam API! These are currently all works-in-progress. Information regarding the documentation of some of these libraries can be found #[a(href='#client-docs') below].
 
             .row
                 .col-xs-4
@@ -35,9 +34,7 @@ block content
             .row
                 .col-xs-12
                     ul
-                        li Java - 
-                            a(href='/doc/java-client/') Application Overview, 
-                            a(href='/doc/java-client/docs/') Documentation (Javadocs)
+                        li Java - #[a(href='/doc/java-client/') Application Overview], #[a(href='/doc/java-client/docs/') Documentation (Javadocs)]
 
         .col-sm-6
             h2 Latest Changelogs

--- a/src/template/index.jade
+++ b/src/template/index.jade
@@ -11,7 +11,8 @@ block content
         .col-sm-6
             h2 Client Libraries
 
-            p We provide several client libraries for easily interacting with the Beam API! These are currently all works-in-progress.
+            p We provide several client libraries for easily interacting with the Beam API! These are currently all works-in-progress. Information regarding the documentation of some of these libraries can be found 
+                a(href='#client-docs') below.
 
             .row
                 .col-xs-4
@@ -26,6 +27,17 @@ block content
                     a.language-panel.php.soon: span PHP #[small Coming Soon]
                 .col-xs-4
                     a.language-panel.ruby.soon: span Ruby #[small Coming Soon]
+
+            h2#client-docs Client Library Documentation
+
+            p In addition to offering several client libraries in different languages, we also offer documentation for some of those libraries!  You can find the links to relevant pieces of documentation below.
+
+            .row
+                .col-xs-12
+                    ul
+                        li Java - 
+                            a(href='/doc/java-client/') Application Overview, 
+                            a(href='/doc/java-client/docs/') Documentation (Javadocs)
 
         .col-sm-6
             h2 Latest Changelogs


### PR DESCRIPTION
This PR adds MCProHosting/beam-client-java as a git submodule in order to generate docs.

The docs are generated via a gulp task, and then are piped into a static directory to serve on the site.

## To-do

- [x] Add java client as submodule
- [x] Add gulp tasks to compile docs
- [x] Add link to javadocs on the frontend
- [x] Fix failing tests